### PR TITLE
Fix resolver related issue

### DIFF
--- a/projects/hg-resolvers/src/lib/resolver.ts
+++ b/projects/hg-resolvers/src/lib/resolver.ts
@@ -200,7 +200,9 @@ export class Resolver<T, D = any> {
         // if we have isFunctionObservableTarget === false as we are in the state of resolving
         target.cancelAction();
       }
-      if (this.previousState !== null) { this.state = this.previousState; }
+      if (this.previousState !== null && ![ResolverState.SETTLED, ResolverState.ERRORED].includes(this.state)) {
+        this.state = this.previousState;
+      }
     }
 
     this._shouldSkip = value;

--- a/src/app/container-with-multiple-resolvers-with-dependencies/container-with-multiple-resolvers-with-dependencies.component.html
+++ b/src/app/container-with-multiple-resolvers-with-dependencies/container-with-multiple-resolvers-with-dependencies.component.html
@@ -5,12 +5,13 @@
   <mat-card-content>
     <p>In this scenario we have a user list resolver and a user post resolver. The user posts resolver is skipped until
       we
-      select a valid userId value. Whenever the userId value is set the user posts resolver will auto resolve (auto load
+      select a valid userId value and while the should skip flag is set to false. Whenever the userId value is set and
+      the skip flag is set to false the user posts resolver will auto resolve (auto load
       the
       data) but that won't
       trigger a user list resolve (For more info look into the user-posts resolver file). We also added the
       [hideContentUntilResolvedSuccessfully]="false" since we want to show the content of the resolve container all the
-      time and actially display the loader/spinner over the content. If you are interested in a more complex loader
+      time and actually display the loader/spinner over the content. If you are interested in a more complex loader
       example check out section 6.
     </p>
     <br />
@@ -19,6 +20,8 @@
     <div>
       <button id="reload-btn" button mat-raised-button color="primary" (click)="resolve.resolve()">Trigger
         Resolve</button>
+      <button id="reload-btn" button mat-raised-button color="primary" (click)="disabledResolving = !disabledResolving">
+        Toggle skip flag: {{(disabledResolving)? 'disabled' : 'enabled'}} resolving </button>
       <br />
       <br />
       <div style="font-style: italic;">Note: UserService loadUsers and PostServie loadPosts have a delay operator
@@ -38,11 +41,11 @@
       <div>{{errors | json}}</div>
     </ng-template>
 
-    <hg-resolve #resolve="hgResolve" [resolveOnInit]="true" appUserListResolver [appUserPostsResolver]="!selectedUserId"
-      [selectedUserId]="selectedUserId" #userListResolver="appUserListResolver"
-      #userPostsResolver="appUserPostsResolver" [loaderTemplateRef]="loader" [autoControlLoader]="true"
-      [hideContentUntilResolvedSuccessfully]="false" [errorTemplateRef]="error" [autoControlError]="true"
-      [resolveOnInit]="true">
+    <hg-resolve #resolve="hgResolve" [resolveOnInit]="true" appUserListResolver
+      [appUserPostsResolver]="!selectedUserId || disabledResolving" [selectedUserId]="selectedUserId"
+      #userListResolver="appUserListResolver" #userPostsResolver="appUserPostsResolver" [loaderTemplateRef]="loader"
+      [autoControlLoader]="true" [hideContentUntilResolvedSuccessfully]="false" [errorTemplateRef]="error"
+      [autoControlError]="true" [resolveOnInit]="true">
       <mat-grid-list cols="4" rowHeight="600px">
         <mat-grid-tile [colspan]="2" [rowspan]="1">
           <div *ngIf="userListResolver.data$ | async" class="resolve-content">

--- a/src/app/container-with-multiple-resolvers-with-dependencies/container-with-multiple-resolvers-with-dependencies.component.ts
+++ b/src/app/container-with-multiple-resolvers-with-dependencies/container-with-multiple-resolvers-with-dependencies.component.ts
@@ -12,6 +12,7 @@ export class ContainerWithMultipleResolversWithDependenciesComponent implements 
   displayedColumns = ['username', 'email', 'name'];
   postsDisplayedColumns = ['userId', 'title'];
 
+  disabledResolving = false;
   constructor() { }
 
   ngOnInit() {

--- a/src/app/container-with-multiple-resolvers-with-dependencies/container-with-multiple-resolvers-with-dependencies.module.ts
+++ b/src/app/container-with-multiple-resolvers-with-dependencies/container-with-multiple-resolvers-with-dependencies.module.ts
@@ -5,7 +5,7 @@ import { UserListResolverDirective } from './-resolvers/user-list.resolver';
 import { SingleResolverRoutingModule } from './container-with-multiple-resolvers-with-dependencies-routing.module';
 import { HGResolversModule } from 'hg-resolvers';
 import { PostListResolverDirective } from './-resolvers/post-list.resolver';
-import { UserPostsResolverDirective } from '../-resolvers/user-posts.resolver';
+import { UserPostsResolverDirective } from './-resolvers/user-posts.resolver';
 import {
   MatTableModule,
   MatButtonModule,


### PR DESCRIPTION
## Fix

If a resolver is already `SETTLED` and we trigger the `sholdSkip` setter it must not return the `state` to it's previous value, as the resolver is already `SETTLED`