### PR TITLE
Change the demo/development serve process

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,10 +20,7 @@
     ],
     "paths": {
       "hg-resolvers": [
-        "dist/hg-resolvers"
-      ],
-      "hg-resolvers/*": [
-        "dist/hg-resolvers/*"
+        "projects/hg-resolvers/src/public-api.ts"
       ]
     }
   },


### PR DESCRIPTION
Either way the thing that is build just exposes the `public.api.ts` so this change probably make the development process faster.